### PR TITLE
pfarrell/bemused_fe#5: Use album art as background on the Album page

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -845,6 +845,32 @@
 }
 
 /* =================================
+   ALBUM PAGE BACKGROUND STYLES
+   ================================= */
+
+.album-page {
+  background-color: #1a1a2e;
+  min-height: 100%;
+  position: relative;
+}
+
+.album-bg {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center top;
+  filter: blur(32px) brightness(0.28) saturate(1.3);
+  transform: scale(1.08);
+  z-index: 0;
+}
+
+.album-page .media-page-header {
+  background: rgba(0, 0, 0, 0.35);
+  border: none;
+  box-shadow: none;
+}
+
+/* =================================
    RESPONSIVE STYLES - DESKTOP
    ================================= */
 

--- a/src/pages/Album.jsx
+++ b/src/pages/Album.jsx
@@ -136,7 +136,11 @@ const Album = () => {
   const { artist, album, tracks, summary, secondary_artists } = albumData;
 
   return (
-    <div style={{ padding: '.5rem', maxWidth: '1400px', margin: '0 auto' }}>
+    <div className="album-page">
+      {album.image_path && (
+        <div className="album-bg" style={{ backgroundImage: `url(${apiService.getImageUrl(album.image_path, 'album_page')})` }} />
+      )}
+      <div style={{ padding: '.5rem', maxWidth: '1400px', margin: '0 auto', position: 'relative', zIndex: 1 }}>
       {/* Album Header */}
       <div className='media-page-header'>
         {/* Album Cover */}
@@ -182,25 +186,25 @@ const Album = () => {
         
         {/* Album Info */}
         <div style={{ flex: 1 }}>
-          <h1 style={{ fontSize: '2.5rem', fontWeight: 'bold', margin: '0 0 0.5rem 0', color: '#7c3aed', cursor: 'pointer' }}
+          <h1 style={{ fontSize: '2.5rem', fontWeight: 'bold', margin: '0 0 0.5rem 0', color: 'white', cursor: 'pointer' }}
             onClick = {reload}
           >
             {album.title}
           </h1>
-          
-          <h2 style={{ fontSize: '1.5rem', fontWeight: 'normal', margin: '0 0 0.5rem 0', color: '#7c3aed', cursor: 'pointer' }}
+
+          <h2 style={{ fontSize: '1.5rem', fontWeight: 'normal', margin: '0 0 0.5rem 0', color: 'white', cursor: 'pointer' }}
             onClick={() => navigate(`/artist/${artist.id}`)}
           >
             {artist.name}
           </h2>
           {secondary_artists && secondary_artists.length > 0 && artist.id !== 161 && (
-            <p style={{ fontSize: '0.95rem', margin: '0 0 1rem 0', color: '#6b7280' }}>
+            <p style={{ fontSize: '0.95rem', margin: '0 0 1rem 0', color: '#d1d5db' }}>
               Also featuring:{' '}
               {secondary_artists.map((sa, i) => (
                 <span key={sa.id}>
                   {i > 0 && ' · '}
                   <span
-                    style={{ color: '#7c3aed', cursor: 'pointer' }}
+                    style={{ color: '#d1d5db', cursor: 'pointer' }}
                     onClick={() => navigate(`/artist/${sa.id}`)}
                   >
                     {sa.name}
@@ -250,11 +254,12 @@ const Album = () => {
               onClick={handlePlayNext}
               style={{
                 padding: '0.5rem 1rem',
-                backgroundColor: 'white',
-                border: '1px solid #d1d5db',
+                backgroundColor: 'transparent',
+                border: '1px solid rgba(255,255,255,0.5)',
                 borderRadius: '4px',
                 cursor: 'pointer',
-                fontSize: '0.875rem'
+                fontSize: '0.875rem',
+                color: 'white'
               }}
             >
               Play Next
@@ -263,11 +268,12 @@ const Album = () => {
               onClick={handleAddToQueue}
               style={{
                 padding: '0.5rem 1rem',
-                backgroundColor: 'white',
-                border: '1px solid #d1d5db',
+                backgroundColor: 'transparent',
+                border: '1px solid rgba(255,255,255,0.5)',
                 borderRadius: '4px',
                 cursor: 'pointer',
-                fontSize: '0.875rem'
+                fontSize: '0.875rem',
+                color: 'white'
               }}
             >
               Add to Queue
@@ -277,7 +283,7 @@ const Album = () => {
           {/* Album Description */}
           {album.description && (
             <div>
-              <p style={{ lineHeight: '1.6', color: '#374151', margin: '0 0 1rem 0' }}>
+              <p style={{ lineHeight: '1.6', color: '#e5e7eb', margin: '0 0 1rem 0' }}>
                 {album.description}
               </p>
             </div>
@@ -294,14 +300,15 @@ const Album = () => {
         overflowY: 'visible'
       }}>
         {tracks.map((track, index) => (
-          <Track 
+          <Track
             key={track.id || index}
-            track={track} 
-            index={index} 
+            track={track}
+            index={index}
             trackCount={tracks.length}
             isPlaying={isTrackPlaying(track)}
           />
         ))}
+      </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Uses album artwork as a full-bleed blurred background on the Album page, replacing the flat `#f5f5f5` surface with a cinematic darkened/blurred rendering of the cover art. The effect is achieved purely via CSS (`filter: blur brightness saturate` + `transform: scale` to hide edge artifacts), which avoids CORS constraints that would block Canvas-based color extraction from the cross-origin image host.

## Changes

**`src/index.css`**
- `.album-page`: full-width wrapper with `position: relative` and `#1a1a2e` dark fallback for albums with no art
- `.album-bg`: absolutely-positioned background layer, `filter: blur(32px) brightness(0.28) saturate(1.3)`, scaled 1.08× to push blurred edges outside the viewport
- `.album-page .media-page-header`: semi-transparent dark overlay strip (`rgba(0,0,0,0.35)`) scoped to the album page for consistent header legibility regardless of image content

**`src/pages/Album.jsx`**
- Root div restructured: outer `.album-page` wrapper + conditionally rendered `.album-bg` div (only when `album.image_path` is truthy) + inner content div with `position: relative; z-index: 1`
- Inline text colors updated for legibility on dark background: title/artist `#7c3aed` → `white`; secondary artist `#6b7280` → `#d1d5db`; description `#374151` → `#e5e7eb`
- "Play Next" / "Add to Queue" buttons changed from opaque white with grey border to `transparent` background with `rgba(255,255,255,0.5)` border and white text

## Review notes

- **No closing `</div>` was added to balance the new inner wrapper** — the diff shows the closing `</div>` moved from before `</div>` (outer) to after the track list, which is correct, but worth verifying the JSX nesting is clean since the indentation in the diff looks slightly off around the closing tags.
- **`album_page` image size variant** is passed to `apiService.getImageUrl`. Confirm this variant is defined on the backend; if not, it will silently fall back to whatever default the API returns (probably fine, but worth checking).
- **No-art fallback** relies on the `album.image_path` truthiness check — albums with `null` or empty string path will show only the `#1a1a2e` background. Verify empty string is also falsy in practice (it is in JS, but confirm the API never returns `""`).
- **Track list contrast**: track rows are unchanged — they retain their existing card/row styling and will float on the dark background. This is intentional but may look slightly disconnected; a reviewer with design context should confirm it looks intentional rather than broken.
- **Mobile**: the existing `.media-page-header` mobile overrides use `[style*="..."]` attribute selectors targeting inline styles; those inline styles were not removed, so mobile layout should be unaffected. Worth a quick smoke test on a narrow viewport.

Closes #5