### PR TITLE
pfarrell/bemused_fe#4: Display album art prominently while a track is playing

### DIFF
--- a/src/components/NowPlaying.jsx
+++ b/src/components/NowPlaying.jsx
@@ -1,6 +1,7 @@
 // src/components/player/NowPlaying.jsx
 import { useNavigate } from 'react-router-dom';
 import { usePlayerStore } from '../stores/playerStore';
+import { apiService } from '../services/api';
 
 const NowPlaying = () => {
   const navigate = useNavigate();
@@ -19,23 +20,35 @@ const NowPlaying = () => {
     return null;
   }
 
+  const albumArtUrl = currentTrack.album?.image_path
+    ? apiService.getImageUrl(currentTrack.album.image_path, 'album_small')
+    : null;
+
   return (
     <div className="now-playing">
-      <svg 
-        width="24" 
-        height="24" 
-        fill="none" 
-        stroke="currentColor" 
-        viewBox="0 0 24 24" 
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path 
-          strokeLinecap="round" 
-          strokeLinejoin="round" 
-          strokeWidth="2" 
-          d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"
+      {albumArtUrl ? (
+        <img
+          src={albumArtUrl}
+          alt={currentTrack.album?.title}
+          className="now-playing-art"
         />
-      </svg>
+      ) : (
+        <svg
+          width="24"
+          height="24"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"
+          />
+        </svg>
+      )}
       <div className="track-info show">
         <div className="track-artist" onClick={() => handleArtistClick(currentTrack)} title="go to artist">
           {currentTrack.artist?.name || currentTrack.artist || 'Unknown Artist'}

--- a/src/index.css
+++ b/src/index.css
@@ -536,7 +536,7 @@
 
 /* Now playing with fixed width */
 .now-playing {
-  display: none; /* Hidden on mobile by default */
+  display: flex;
   align-items: center;
   gap: 0.75rem;
   color: white;
@@ -551,6 +551,14 @@
   color: #ffffff;
   width: 24px;
   height: 24px;
+}
+
+.now-playing-art {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: 3px;
+  flex-shrink: 0;
 }
 
 .now-playing .track-info {
@@ -981,11 +989,11 @@
     padding: 0 1rem;
   }
   
-  /* Hide now-playing on mobile */
+  /* now-playing visible on mobile: shows album art alongside player controls */
   .now-playing {
-    display: none !important;
+    max-width: 48px;
   }
-  
+
   .playlist-button {
     padding: 0.25rem;
     font-size: 0.875rem;


### PR DESCRIPTION
Displays album art thumbnail in the now-playing footer strip when a track is playing. When `currentTrack.album.image_path` is present, the music note SVG is replaced by the actual album art via `apiService.getImageUrl`. The SVG is retained as a fallback for tracks without image metadata (e.g. search results or playlists that don't carry `image_path`). The mobile breakpoint override (`display: none !important`) is replaced with `max-width: 48px`, making the component visible on small screens but constraining it to the thumbnail so it doesn't crowd the player controls.

## Changes

- **`src/components/NowPlaying.jsx`**: Imports `apiService`; derives `albumArtUrl` from `currentTrack.album?.image_path`; renders `<img className="now-playing-art">` when the URL resolves, otherwise falls back to the existing SVG.
- **`src/index.css`**: Changes `.now-playing` base rule from `display: none` to `display: flex` (the component is now always mounted but width-capped on mobile). Adds `.now-playing-art` rule: `40×40px`, `object-fit: cover`, `border-radius: 3px`. Replaces the mobile `display: none !important` override with `max-width: 48px`.

## Review notes

- **`image_path` availability**: The plan flagged this as unknown. The implementation assumes `currentTrack.album.image_path` is serialized by the backend into the track object passed to `onTrackStart`. If the API omits it, the component silently falls back to the SVG — no broken state — but the feature won't activate. Confirm with a real API response before merging.
- **Mobile layout tradeoff**: Option A from the plan was taken — `.now-playing` is now visible on mobile, capped at 48px wide. This shows only the thumbnail (track text overflows/clips at that width). If the design intent is to show track title on mobile too, the player controls row will need a width audit to avoid crowding the scrubber and transport buttons.
- **Footer height**: The 40px thumbnail fits within the existing 4.5em footer without overflow, so no height adjustment was needed. Verify on a device/emulator where system font scaling is increased.
- **Alt text**: `alt` is set to `currentTrack.album?.title`, which is the album name rather than a description of the image. Acceptable for decorative art but worth a second opinion if accessibility is a priority.

Closes #4