### PR TITLE
Fix review feedback: PR #19

### DIFF
--- a/server/schema.sql
+++ b/server/schema.sql
@@ -1025,7 +1025,8 @@ CREATE TABLE public.users (
     password text,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    admin boolean DEFAULT false
+    admin boolean DEFAULT false,
+    default_tag character varying(255) DEFAULT NULL
 );
 
 

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -16,35 +16,34 @@ type AppContext = Context<{ Variables: Variables }>
 
 // Middleware to extract and verify JWT from cookie
 export async function authMiddleware(c: AppContext, next: Next) {
-  try {
-    const token = getCookie(c, 'auth')
+  const token = getCookie(c, 'auth')
 
-    if (!token) {
-      // No token, continue without user
-      await next()
-      return
-    }
-
-    // Verify and decode token
-    const decoded = jwt.verify(token, JWT_SECRET) as JWTPayload
-
-    // Fetch user from database
-    const user = await db
-      .selectFrom('users')
-      .select(['id', 'username', 'email', 'admin', 'default_tag'])
-      .where('id', '=', decoded.id)
-      .executeTakeFirst()
-
-    if (user) {
-      // Set user in context for downstream handlers
-      c.set('user', user)
-    }
-
+  if (!token) {
     await next()
-  } catch (error) {
-    // Invalid token, continue without user
-    await next()
+    return
   }
+
+  let decoded: JWTPayload
+  try {
+    decoded = jwt.verify(token, JWT_SECRET) as JWTPayload
+  } catch {
+    // Invalid or expired token — proceed without user
+    await next()
+    return
+  }
+
+  // DB errors propagate rather than silently clearing the user context
+  const user = await db
+    .selectFrom('users')
+    .select(['id', 'username', 'email', 'admin', 'default_tag'])
+    .where('id', '=', decoded.id)
+    .executeTakeFirst()
+
+  if (user) {
+    c.set('user', user)
+  }
+
+  await next()
 }
 
 // Middleware to require authentication


### PR DESCRIPTION
Automated fixes from PR review #19.

## Changes
- Add the actual auth fix for the 401 on admin edit pages (likely a field name or ordering issue in `server/src/middleware/`) — this is the core work claimed by #18 and is absent from the diff
- Add `DEFAULT NULL` to the `default_tag` column definition in `server/schema.sql` to match the migration: `default_tag character varying(255) DEFAULT NULL`