### PR TITLE
pfarrell/bemused_fe#21: Rewrite CLAUDE.md to reflect full-stack monorepo architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,47 +4,149 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Commands
 
+### Frontend (root)
+
 ```bash
-npm run dev       # Start dev server (proxies /api to localhost:9292)
-npm run build     # Production build (sets base to /bemused/frontend/)
-npm run lint      # Run ESLint
-npm run deploy    # Build and rsync to patf.com via SSH on port 10022
+npm run dev          # Vite dev server — proxies /api → localhost:3000 (prefix stripped)
+npm run build        # Production build (base URL /bemused/app/)
+npm run lint         # ESLint
+npm run deploy       # Build and rsync frontend to /var/www/bemused/shared/public/frontend on patf.com
+npm run full-deploy  # Build and deploy both frontend and backend
 ```
+
+### Backend (server/)
+
+```bash
+npm run dev          # tsx watch — API server on port 3000
+npm run build        # TypeScript compile
+npm run start        # Run compiled JS
+npm run worker       # Upload queue worker — must run as a separate process alongside dev server
+npm run deploy       # Build and deploy to /var/www/bemused-node/releases/<timestamp> with symlinked current
+npm run db:snapshot  # Dump PostgreSQL database to snapshots/
+npm run db:restore   # Restore from a snapshot
+npm run db:schema:dump  # Dump schema-only SQL to schema.sql
+npm run db:reset     # Reset database
+```
+
+**Deploy commands by change type**: `npm run deploy` (frontend changes only), `cd server && npm run deploy` (backend changes only), `npm run full-deploy` (both layers changed).
 
 ## Specs and Plans
 
 Design specs live in `docs/superpowers/specs/` and implementation plans in `docs/superpowers/plans/`. Never commit these files to git.
 
-After writing a spec or plan, always push it to Recall using the same title for both so they land in the same folio:
-
-```bash
-~/.local/bin/recall push <file_path> --title "<Feature Name>" --tags "bemused,<topic>,specs" --type writing
-```
-
 There are no tests.
 
 ## Architecture
 
-This is a React SPA for a personal music streaming service called "P·Share". It talks to a backend API (a separate Ruby/Rack app running on port 9292 in dev, `https://patf.net/bemused` in production).
+This is a React SPA monorepo for a personal music streaming service called "P·Share". The monorepo has two layers: `src/` (React SPA frontend) and `server/` (Hono + Kysely + PostgreSQL backend). The Vite dev server proxies `/api` → `http://localhost:3000`, stripping the `/api` prefix — backend routes do **not** use an `/api` prefix. In production, the frontend deploys to `/var/www/bemused/shared/public/frontend` and the backend deploys to `/var/www/bemused-node/` with symlinked releases.
 
-**Routing** (`src/App.jsx`): `/login` renders without a layout; all other routes render inside `Layout`. The basename switches between `/` (dev) and `/bemused/app` (prod) via `import.meta.env.DEV`.
+Images are served externally: `https://patf.net/images/` in production, `/images` in dev. The backend deploy symlinks `public/images` from a NAS share rather than serving images through the Node app.
 
-**Layout** (`src/components/Layout.jsx`): Fixed header with `SearchBar`, scrollable `.main-content` div, fixed footer with `NowPlaying` + `MusicPlayerWrapper`.
+## Frontend
+
+**Routing** (`src/App.jsx`): All routes render inside `Layout`. The basename switches between `/` (dev) and `/bemused/app` (prod) via `import.meta.env.DEV`. Admin routes are wrapped in `<ProtectedRoute requireAdmin>`. Routes:
+- `/` — Home (artist or album grid)
+- `/search` — Search
+- `/login`, `/signup` — Auth forms
+- `/artist/:id`, `/album/:id` — Artist and album detail
+- `/library` — User library
+- `/playlists`, `/playlist/:id` — Playlists list and detail
+- `/collections`, `/collection/:id` — Collections list and detail
+- `/tags/:name` — Tag browse
+- `/admin/artist/:id`, `/admin/album/:id`, `/admin/collection/:id`, `/admin/playlist/:id` — Admin edit pages (require admin)
+- `/admin/upload`, `/admin/logs`, `/admin/new` — Admin upload, log viewer, entity creation (require admin)
+
+**Layout** (`src/components/Layout.jsx`): Fixed header with `SearchBar`, active tag filter chip (links to `/tags/:name`, has clear button), and hamburger/user menu containing: home mode toggle (artists/albums), tag filter with autocomplete (fetches `getTags()` lazily when menu opens), and nav links. Scrollable `.main-content` div with pull-to-refresh (increments `refreshKey` to remount current page on pull ≥ 60px). Fixed footer with `NowPlaying` + `MusicPlayerWrapper`.
 
 **Audio player**: An external `window.AudioPlayer` class is loaded at runtime from `player.js` (served from `public/` in dev, `/bemused/frontend/player.js` in prod). `MusicPlayerWrapper` instantiates it and registers it in `playerStore`. All other components that want to play audio get `playerInstance` from `usePlayerStore()` and call its methods directly (`clearPlaylist`, `addTrack`, `addTracks`, `loadAndPlayTrack`).
 
-**State management** (`src/stores/`): Two Zustand stores:
-- `playerStore` — holds `currentTrack`, `playlist`, `isPlaying`, `playerInstance`, `currentTrackIndex`. The store's `playerInstance` is the live `window.AudioPlayer` object.
-- `authStore` — holds `user`, `isAuthenticated`, `isAdmin`. Auth token is stored in `localStorage` as `authToken` and attached to all API calls via an axios interceptor.
+**State management** (`src/stores/`): Four Zustand stores:
+- `playerStore` — `currentTrack`, `playlist`, `isPlaying`, `playerInstance`, `currentTrackIndex`. `playerInstance` is the live `window.AudioPlayer` object.
+- `authStore` — `user`, `isAuthenticated`, `isAdmin`, `loading`. Auth uses httpOnly cookie (set by backend). Calls `initialize()` on app start to check `/auth/me`. On login/init, populates `tagFilterStore` from `user.default_tag`.
+- `tagFilterStore` — `activeTag` (persisted to `localStorage` as `tag-filter`). Tag filters the home feed and is shown as a chip in the header.
+- `homeModeStore` — `mode` (`'artists'` | `'albums'`, persisted to `localStorage` as `home-mode`). Controls whether Home shows an artist grid or album grid.
 
-**API** (`src/services/api.js`): Single axios instance. `apiService.getImageUrl(imagePath, context)` maps image paths to absolute URLs at `https://patf.net/images/` using context strings: `artist_search`, `artist_page`, `album_small`, `album_page`. The `apiService.log(id)` call fires at the 5-second mark of a track via the `onFiveSecondMark` player callback.
+**API** (`src/services/api.js`): Single axios instance. Base URL is `/api` in dev (proxied to `localhost:3000`) and `/bemused/api` in production. `withCredentials: true` for httpOnly cookie auth. Methods are grouped by domain: auth, artists, albums, tags, search, log, admin (artist/album/track/relation/image ops), upload, playlists, collections, image management. `apiService.getImageUrl(imagePath, context)` constructs absolute URLs at `https://patf.net/images/` (prod) or `/images` (dev) using context strings: `artist_search`, `artist_page`, `album_small`, `album_page`. `apiService.log(id)` fires at the 5-second mark of each track via the `onFiveSecondMark` player callback.
 
-**Pages and data shapes**:
-- `Home` — fetches `getRandomArtists(60)` → array of artist objects
-- `Artist` (`/artist/:id`) — fetches `getArtist(id)` → `{ artist, summary, albums }`. Clicking the artist name triggers a data reload.
-- `Album` (`/album/:id`) — fetches `getAlbum(id)` → `{ artist, album, tracks, summary }`. Clicking the album title triggers a reload.
+**Pages** (`src/pages/`):
+- `Home` — random artists or albums grid (controlled by `homeModeStore`), tag-filtered via `tagFilterStore`
+- `Artist` (`/artist/:id`) — fetches `getArtist(id)` → `{ artist, summary, albums }`; clicking artist name reloads
+- `Album` (`/album/:id`) — fetches `getAlbum(id)` → `{ artist, album, tracks, summary }`; clicking album title reloads
 - `Search` (`/search?q=...`) — fetches `search(query)` → `{ artists, albums, tracks, playlists }`
+- `Library` — user's personal library view
+- `Playlists` — list all playlists
+- `Playlist` — single playlist with track list
+- `Collections` — list all collections
+- `Collection` — single collection with album list
+- `TagPage` — browse artists and albums tagged with a given tag
+- `Login`, `Signup` — authentication forms
+- `AdminArtist`, `AdminAlbum` — edit metadata, manage images and artist relations
+- `AdminCollection`, `AdminPlaylist` — edit collection or playlist metadata and contents
+- `AdminUpload` — upload audio files; polls upload queue status
+- `AdminLogs` — paginated playback log viewer
+- `AdminNew` — create new artist or album records
 
-**Track component** (`src/components/Track.jsx`): Accepts `{ track, index, trackCount, includeMeta, isPlaying }`. When `includeMeta=true` (used in Search), shows album/artist links below the title. Track objects have the shape `{ id, title, duration, artist: { id, name }, album: { id, title, artist: { id, name } } }`.
+**Key components** (`src/components/`):
+- `Track` — accepts `{ track, index, trackCount, includeMeta, isPlaying }`; `includeMeta=true` shows album/artist links (used in Search)
+- `SearchBar` — search input, navigates to `/search?q=…`
+- `NowPlaying` — current track display in footer
+- `MusicPlayerWrapper` — instantiates `window.AudioPlayer`, registers in `playerStore`
+- `ProtectedRoute` — redirects to `/login` if not authenticated; `requireAdmin` prop also enforces admin role
 
-**Styling**: Tailwind v4 + custom CSS in `src/index.css`. CSS classes (`.app-header`, `.main-content`, `.app-footer`, `.artist-grid`, `.track-item`, `.now-playing`, etc.) are defined there. The layout uses fixed header/footer (4.5em each) with a flex-column body. Many mobile overrides use `!important` due to competing inline styles on page components.
+**Styling**: Tailwind v4 + custom CSS in `src/index.css`. CSS classes (`.app-header`, `.main-content`, `.app-footer`, `.artist-grid`, `.track-item`, `.now-playing`, etc.) are defined there. Fixed header/footer (4.5em each). Many mobile overrides use `!important` due to competing inline styles on page components.
+
+## Backend
+
+**Entry point** (`server/src/index.ts`): Hono app on port 3000 (configurable via `PORT` env var). Global middleware: `cors` (all origins in dev; allowlist of patf.net/patf.com/172.16.1.10 in prod) and `authMiddleware` (extracts user from httpOnly `auth` cookie into `c.get('user')`). Admin routes mount a sub-app with `requireAdmin` guard.
+
+**Route modules** (`server/src/routes/`):
+- `auth` (`/auth`) — login, logout, signup, `/auth/me`, default-tag update
+- `artists` (`/artists`, `/artist`) — list, random (tag-filterable), detail; singular alias used by frontend
+- `albums` (`/albums`, `/album`) — list, random (tag-filterable), detail; singular alias
+- `search` (`/search`) — full-text search across artists, albums, tracks, playlists
+- `streams` (`/stream`) — audio file streaming
+- `logs` (`/log`) — playback event logging; admin log viewer
+- `playlists` (`/playlist`, `/playlists`, `/top`, `/newborns`, `/surprise`) — playlist CRUD and auto-generated views
+- `collections` (`/collection`, `/collections`) — collection CRUD
+- `tags` (`/tags`) — tag CRUD; `/tags/:name/content` for tag browse
+- `admin` (`/admin`) — artist/album/track admin ops, image download, artist relations, stub merging (protected by `requireAdmin`)
+- `upload` (`/admin/upload`) — multipart file upload (2GB body limit); inserts to `upload_queue` and returns immediately; processing deferred to worker
+
+**Database** (`server/src/db/database.ts`): Kysely with `pg.Pool` (max 10 connections). Connection string from `BEMUSED_DB` env var. Tables:
+- `artists` — name, image path, Wikipedia text, MusicBrainz ID + confidence + status
+- `albums` — title, artist FK, year, disc number, genre, image path, Wikipedia, MusicBrainz metadata
+- `tracks` — title, number, year, album/artist FKs, media file FK, Wikipedia, duration
+- `media_files` — file system records linking audio files to entities; `entity_id`/`entity_type` for current records (`track_id` is legacy)
+- `playlists` — named playlists with optional user ownership and auto-generated flag
+- `playlist_tracks` — ordered join table for playlist ↔ track
+- `logs` — playback events: track/album/artist IDs, action, IP, timestamp
+- `favorites` — user ↔ entity favorites by kind (artist/album/track)
+- `upload_queue` — pending/processing/completed/failed upload jobs with full file and metadata fields
+- `users` — username, email, bcrypt password, admin flag, default_tag
+- `user_playlists` — user ↔ playlist with role
+- `artist_albums` — many-to-many artist ↔ album with role (primary/compilation/featured/guest/collaborator) and order
+- `artist_relations` — similar/related artist pairs with source, similarity score, `is_hidden`, `force_show`
+- `external_lookups` — cache of results from external service lookups (entity_type, entity_id, service)
+- `images` — image records for artists/albums with source, status, dimensions, primary flag
+- `collections` — named album collections
+- `collection_albums` — ordered join table for collection ↔ album
+- `tags` — tag names
+- `albums_tags`, `artists_tags`, `tags_tracks` — many-to-many tag associations
+
+**Auth** (`server/src/middleware/auth.ts`): JWT in httpOnly `auth` cookie, 24h expiry. `authMiddleware` runs globally and sets `c.get('user')` if cookie is valid. `requireAdmin` blocks non-admin users with 403. Passwords hashed with bcrypt.
+
+**Upload flow**: `POST /admin/upload` accepts multipart (2GB body limit), writes files to a temp dir, inserts rows into `upload_queue` with `status: 'pending'`, returns immediately.
+
+**Queue worker** (`server/src/workers/queue-handler.ts`): Run via `cd server && npm run worker` — a **separate process** from the API server, required for uploads to be processed. Polls `upload_queue` every 5 seconds for `pending` rows. For each: extracts ID3 tags, resolves or creates artist/album/track records, moves file to `$BEMUSED_UPLOAD_PATH/{artist}/{album}/{track}.mp3`, creates a `MediaFile` record, updates queue status to `completed` or `failed`. MBID lookup and similar-artist side effects run non-blocking.
+
+**Migrations** (`server/migrations/`): 20 SQL files (`000`–`019`). Runner at `server/scripts/run-migrations.js` tracks applied migrations in `schema_migrations` table. Migrations run automatically on every backend deploy.
+
+**External services** (`server/src/services/`): All calls are non-blocking; used by the worker and admin scripts:
+- `musicbrainz` — MBID lookups for artists and albums
+- `coverArtArchive` — album art from Cover Art Archive
+- `fanart` — artist/album images from Fanart.tv
+- `lastfm` — artist/album metadata from Last.fm
+- `lastfmSimilar` — similar artist data from Last.fm
+- `listenbrainzSimilar` — similar artists from ListenBrainz
+- `wikipedia` — artist/album summaries from Wikipedia API
+- `imageResize` — image resizing via `sharp`


### PR DESCRIPTION
Rewrites `CLAUDE.md` from its original ~70-line description of a React SPA talking to an external Ruby/Rack backend into an accurate ~200-line reference for the current full-stack monorepo: React SPA in `src/` + Hono/Kysely/PostgreSQL backend in `server/`. The previous file was written before the backend was brought in-tree and contained outdated references to Ruby, Rack, port 9292, and `/bemused` endpoint paths that caused agents to generate incorrect code and API call examples.

## Changes

- **Commands section**: Split into Frontend (root) and Backend (`server/`) subsections. Documents all `npm run *` scripts for both layers including `worker`, `db:snapshot`, `db:restore`, `db:reset`, `db:schema:dump`, and `full-deploy`. Adds explicit guidance on which deploy command applies to which change type.
- **Architecture section**: Replaces the Ruby/Rack/port-9292 description with the monorepo layout. Calls out the Vite proxy's prefix-stripping behaviour (`/api` → `http://localhost:3000`, prefix dropped) — backend routes have no `/api` prefix. Clarifies production deploy targets for both layers. Notes that images are still served externally via `https://patf.net/images/` (NAS symlink, not through Node).
- **Frontend section**: Expands routing from 4 routes to all 22, documents `Layout` tag-filter UI and pull-to-refresh, updates stores from 2 to 4 (`tagFilterStore`, `homeModeStore` added), notes httpOnly cookie auth replacing the old `localStorage` token + axios interceptor pattern, and documents the API service by pattern/grouping rather than enumerating all 50+ methods.
- **Backend section** (new): Covers entry point, all 11 route modules, Kysely DB layer (20 tables), JWT auth + `requireAdmin` guard, upload flow, queue worker (5s poll, ID3 extraction, file move), migrations (20 SQL files, auto-run on deploy), and 8 external service integrations.
- **Spec/plan commit prohibition**: Carried over verbatim.
- **Recall push workflow**: Removed entirely.

## Review notes

- The Vite proxy prefix-stripping detail (`/api` stripped before forwarding) is documented explicitly because it's the most common source of agent confusion — verify the wording is unambiguous to a reader who hasn't seen `vite.config.js`.
- Image URL handling is intentionally kept as `https://patf.net/images/` in the frontend section. This is still correct — it was not an artifact of the Ruby backend. Do not treat it as a leftover stale reference.
- The worker as a separate process (`npm run worker` must run independently from `npm run dev`) is called out in the Commands section. If this isn't prominent enough, it could be promoted to a callout block.
- The API service section documents patterns and groupings only, not individual methods. If reviewers feel any groupings (e.g. admin, playlists, collections) warrant explicit method signatures, those can be added, but the intent is to avoid the file bloating as the API grows.
- No code was changed — this is documentation only. The diff is purely `CLAUDE.md`.

Closes #21