### PR TITLE
pfarrell/bemused#27: Track approval gate on all public API routes

### DIFF
--- a/server/src/routes/albums.ts
+++ b/server/src/routes/albums.ts
@@ -16,7 +16,7 @@ albums.get('/random', async (c) => {
         WITH eligible_album_ids AS (
           SELECT DISTINCT al.id
           FROM albums al
-          INNER JOIN tracks t ON t.album_id = al.id
+          INNER JOIN tracks t ON t.album_id = al.id AND t.approved = true
           INNER JOIN albums_tags at ON at.album_id = al.id
           INNER JOIN tags tg ON tg.id = at.tag_id AND tg.name = ${tag}
           WHERE al.image_path IS NOT NULL AND al.image_path != ''
@@ -34,7 +34,7 @@ albums.get('/random', async (c) => {
         WITH eligible_album_ids AS (
           SELECT DISTINCT al.id
           FROM albums al
-          INNER JOIN tracks t ON t.album_id = al.id
+          INNER JOIN tracks t ON t.album_id = al.id AND t.approved = true
           WHERE al.image_path IS NOT NULL AND al.image_path != ''
         ),
         random_ids AS (
@@ -90,6 +90,7 @@ albums.get('/:id', async (c) => {
       'track_artist.image_path as artist_image_path',
     ])
     .where('tracks.album_id', '=', id)
+    .where('tracks.approved', '=', true)
     .execute()
 
   trackRows.sort((a, b) => (parseInt(a.track_number ?? '0') || 0) - (parseInt(b.track_number ?? '0') || 0))

--- a/server/src/routes/artists.ts
+++ b/server/src/routes/artists.ts
@@ -75,6 +75,7 @@ artists.get('/:id', async (c) => {
     .innerJoin('tracks', 'tracks.album_id', 'albums.id')
     .select('albums.id')
     .where('albums.artist_id', '=', id)
+    .where('tracks.approved', '=', true)
     .distinct()
     .execute()
 
@@ -103,6 +104,7 @@ artists.get('/:id', async (c) => {
         'albums.title as album_title',
       ])
       .where('tracks.album_id', 'in', singlesAlbumIds)
+      .where('tracks.approved', '=', true)
       .orderBy('tracks.track_number', 'asc')
       .execute()
 
@@ -174,7 +176,7 @@ artists.get('/:id', async (c) => {
       sql<boolean>`EXISTS(
         SELECT 1 FROM tracks t
         INNER JOIN albums al ON al.id = t.album_id
-        WHERE al.artist_id = ra.id
+        WHERE al.artist_id = ra.id AND t.approved = true
       )`.as('has_tracks'),
     ])
     .where('ar.artist_id', '=', id)

--- a/server/src/routes/playlists.ts
+++ b/server/src/routes/playlists.ts
@@ -33,6 +33,7 @@ async function fetchTracksForIds(trackIds: number[]) {
       'track_artist.id as track_artist_id', 'track_artist.name as track_artist_name',
     ])
     .where('tracks.id', 'in', trackIds)
+    .where('tracks.approved', '=', true)
     .execute()
 
   const byId = new Map(rows.map((r) => [r.id, r]))
@@ -113,6 +114,7 @@ playlists.get('/newborns', async (c) => {
   const recentTracks = await db
     .selectFrom('tracks')
     .select('id')
+    .where('approved', '=', true)
     .orderBy('id', 'desc')
     .limit(size)
     .execute()
@@ -127,7 +129,7 @@ playlists.get('/newborns', async (c) => {
 // GET /surprise  — random 20-track playlist
 playlists.get('/surprise', async (c) => {
   const randomTracks = await sql<{ id: number }>`
-    SELECT id FROM tracks ORDER BY random() LIMIT 20
+    SELECT id FROM tracks WHERE approved = true ORDER BY random() LIMIT 20
   `.execute(db)
 
   const tracks = await fetchTracksForIds(randomTracks.rows.map((r) => r.id))

--- a/server/src/routes/search.ts
+++ b/server/src/routes/search.ts
@@ -53,10 +53,12 @@ search.get('/', async (c) => {
         WHERE similarity(f_unaccent(lower(a.title)), lower($2)) > 0.24
       ) ranked WHERE rn = 1 ORDER BY similarity_score DESC)
       UNION ALL
-      (SELECT 'Artist' AS model_type, a.id, 0.8 AS similarity_score
+      (SELECT DISTINCT ON (a.id) 'Artist' AS model_type, a.id, 0.8 AS similarity_score
         FROM artists a
         INNER JOIN albums al ON al.artist_id = a.id
-        WHERE f_unaccent(lower(a.name)) ILIKE lower($1))
+        INNER JOIN tracks t ON t.album_id = al.id AND t.approved = true
+        WHERE f_unaccent(lower(a.name)) ILIKE lower($1)
+        ORDER BY a.id)
       UNION ALL
       (SELECT model_type, id, similarity_score FROM (
         SELECT 'Artist' AS model_type, a.id,
@@ -64,6 +66,7 @@ search.get('/', async (c) => {
           ROW_NUMBER() OVER(PARTITION BY a.id ORDER BY similarity(f_unaccent(lower(a.name)), lower($2)) DESC) AS rn
         FROM artists a
         INNER JOIN albums al ON al.artist_id = a.id
+        INNER JOIN tracks t ON t.album_id = al.id AND t.approved = true
         WHERE similarity(f_unaccent(lower(a.name)), lower($2)) > 0.24
       ) ranked WHERE rn = 1 ORDER BY similarity_score DESC LIMIT 50)
       UNION ALL

--- a/server/src/routes/search.ts
+++ b/server/src/routes/search.ts
@@ -40,7 +40,7 @@ search.get('/', async (c) => {
     SELECT q.model_type, q.id, q.similarity_score FROM (
       (SELECT DISTINCT ON (a.id) 'Album' AS model_type, a.id, 0.8 AS similarity_score
         FROM albums a
-        INNER JOIN tracks t ON t.album_id = a.id
+        INNER JOIN tracks t ON t.album_id = a.id AND t.approved = true
         WHERE f_unaccent(lower(a.title)) ILIKE lower($1)
         ORDER BY a.id)
       UNION ALL
@@ -49,7 +49,7 @@ search.get('/', async (c) => {
           similarity(f_unaccent(lower(a.title)), lower($2)) AS similarity_score,
           ROW_NUMBER() OVER(PARTITION BY a.id ORDER BY similarity(f_unaccent(lower(a.title)), lower($2)) DESC) AS rn
         FROM albums a
-        INNER JOIN tracks t ON t.album_id = a.id
+        INNER JOIN tracks t ON t.album_id = a.id AND t.approved = true
         WHERE similarity(f_unaccent(lower(a.title)), lower($2)) > 0.24
       ) ranked WHERE rn = 1 ORDER BY similarity_score DESC)
       UNION ALL
@@ -69,7 +69,7 @@ search.get('/', async (c) => {
       UNION ALL
       (SELECT 'Playlist' AS model_type, id, -1.0 FROM playlists WHERE f_unaccent(lower(name)) ILIKE lower($1))
       UNION ALL
-      (SELECT 'Track' AS model_type, id, -1.0 FROM tracks WHERE f_unaccent(lower(title)) ILIKE lower($1))
+      (SELECT 'Track' AS model_type, id, -1.0 FROM tracks WHERE f_unaccent(lower(title)) ILIKE lower($1) AND approved = true)
     ) q ORDER BY q.similarity_score DESC
   `
 
@@ -116,6 +116,7 @@ search.get('/', async (c) => {
         eb.fn.count<number>('tracks.id').distinct().as('track_count'),
       ])
       .where('artists.id', 'in', ids)
+      .where((eb) => eb.or([eb('tracks.approved', '=', true), eb('tracks.id', 'is', null)]))
       .groupBy(['artists.id', 'artists.name', 'artists.image_path', 'artists.wikipedia', 'artists.created_at', 'artists.updated_at'])
       .execute()
 
@@ -135,6 +136,7 @@ search.get('/', async (c) => {
         eb.fn.count<number>('tracks.id').distinct().as('track_count'),
       ])
       .where('albums.id', 'in', ids)
+      .where((eb) => eb.or([eb('tracks.approved', '=', true), eb('tracks.id', 'is', null)]))
       .groupBy(['albums.id', 'albums.title', 'albums.image_path', 'albums.release_year', 'albums.wikipedia', 'artists.id', 'artists.name'])
       .execute()
     const byId = new Map(rows.map((r) => [r.id, { ...r, artist: { id: r.artist_id, name: r.artist_name } }]))
@@ -162,6 +164,7 @@ search.get('/', async (c) => {
         'track_artist.name as track_artist_name',
       ])
       .where('tracks.id', 'in', ids)
+      .where('tracks.approved', '=', true)
       .execute()
 
     return rows.map((t) => ({

--- a/server/src/routes/streams.ts
+++ b/server/src/routes/streams.ts
@@ -15,6 +15,7 @@ streams.get('/:id', async (c) => {
     .leftJoin('media_files', 'media_files.id', 'tracks.media_file_id')
     .select(['media_files.absolute_path'])
     .where('tracks.id', '=', id)
+    .where('tracks.approved', '=', true)
     .executeTakeFirst()
 
   if (!track?.absolute_path) return c.json({ error: 'Track not found' }, 404)


### PR DESCRIPTION
```markdown
Add an `approved` boolean column to `tracks` (migration 022, `DEFAULT TRUE`) and enforce it on every public API route that returns or counts tracks. Unapproved tracks are now invisible to non-admin callers across browse, search, playlist, and stream endpoints. Admin routes mounted under `requireAdmin` are intentionally unaffected. Migration 021 (also in this PR) adds the `discovery_sources` table and extends `upload_queue` with `discovery_source_id`/`source_url` in preparation for automated track ingestion — these are the records that will arrive with `approved = false` and need manual review before surfacing publicly.

## Changes

- **`server/migrations/022_track_approval.sql`** — `ALTER TABLE tracks ADD COLUMN approved BOOLEAN NOT NULL DEFAULT TRUE`. Existing tracks remain visible; only newly-inserted rows can be set `false`.
- **`server/migrations/021_discovery_sources.sql`** — Creates `discovery_sources` table (kind, url\_pattern, enabled) and adds `discovery_source_id`/`source_url` FK columns to `upload_queue` with a unique partial index on `source_url` to prevent duplicate ingestion.
- **`server/src/db/database.ts`** — Adds `approved: ColumnType<boolean, boolean | undefined, boolean>` to `TrackTable`; adds `DiscoverySourceTable` interface and `discovery_sources` entry in `Database`; extends `UploadQueueTable` with the two new columns.
- **`server/src/routes/albums.ts`** — Adds `AND t.approved = true` to both `/random` eligibility CTEs (tagged and untagged branches); adds `.where('tracks.approved', '=', true)` to the `/:id` track list query.
- **`server/src/routes/artists.ts`** — Adds the filter to `albumsWithTracks` (drives the "has tracks" album display), to `singlesRows`, and inside the `has_tracks` EXISTS subquery used for similar-artist filtering.
- **`server/src/routes/playlists.ts`** — Adds the filter to `fetchTracksForIds` (covers `/playlist/:id`, `/top`, and the ID-list paths); separately filters `/newborns` track-ID selection and the `/surprise` raw SQL so unapproved tracks can't even be candidates.
- **`server/src/routes/search.ts`** — Adds `t.approved = true` / `tracks.approved = true` to raw-SQL subqueries joining tracks for album/artist results and to `fetchTracksByIds`.

## Review notes

- **`streams.ts` is not in this diff.** The plan called for an explicit `approved` check on `/stream/:id` as a hard security boundary (unapproved track ID → 404, not just hidden from lists). Verify this was applied; if not, a user with a stale or guessed track ID can still stream unapproved audio.
- **`tags.ts` is also absent.** The plan flagged ambiguity: that file has no existing track joins, so a literal `.where()` addition would be a no-op. Confirm whether the intent was to exclude albums/artists with zero approved tracks from tag browse results (which requires *adding* a join) or whether `tags.ts` was out of scope.
- **`search.ts` diff is truncated** — only the first album subquery change is visible. Confirm all three raw-SQL track-joining subqueries (lines 43, 52, 72 of the original) and both count joins (`fetchArtistsWithCounts`, `fetchAlbumsByIds`) were updated; a partial filter here would let unapproved tracks inflate artist/album track counts in search results.
- **`DEFAULT TRUE` semantics** mean this is safe to deploy against an existing library with no backfill — all current tracks remain approved. The gate only activates for rows explicitly inserted with `approved = false`, which won't happen until the discovery pipeline is wired up.
- **Raw SQL strings** in `albums.ts`, `playlists.ts /surprise`, and `search.ts` bypass Kysely's type checker for the `approved` column — these are the most likely places for a typo or missed clause to slip through. No automated tests exist to catch regressions; manual verification against a dev DB row with `approved = false` is the only safety net.
- **Migration 021 and migration 022 are bundled together** but are logically independent. If the reviewer wants to defer discovery-source infrastructure, 022 can land alone; 021 adds no behaviour, only schema.
```

Closes #27