### PR TITLE
pfarrell/bemused#41: PWA: header and footer are ~2.5x too tall on iPhone (safe-area inset inflation)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta content='width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=0' name='viewport'>
+    <meta content='width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=0, viewport-fit=cover' name='viewport'>
     <link rel="icon" type="image/svg+xml" href="/bemused.ico" />
     <link href='/opensearch.xml' rel='search' title='PShare' type='application/opensearchdescription+xml'>
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/src/index.css
+++ b/src/index.css
@@ -950,7 +950,7 @@
     padding-top: env(safe-area-inset-top, 0);
     padding-left: env(safe-area-inset-left, 1.5rem);
     padding-right: env(safe-area-inset-right, 1.5rem);
-    height: calc(4.5em + env(safe-area-inset-top, 0));
+    height: 4.5em;
   }
 
   /* Footer adjustments */
@@ -958,7 +958,7 @@
     padding-bottom: env(safe-area-inset-bottom, 0);
     padding-left: env(safe-area-inset-left, 0);
     padding-right: env(safe-area-inset-right, 0);
-    height: calc(4.5em + env(safe-area-inset-bottom, 0));
+    height: 4.5em;
   }
 
   /* Main content */
@@ -1423,7 +1423,7 @@
 /* iOS Safari specific fixes */
 @supports (-webkit-touch-callout: none) {
   .main-content {
-    height: calc(100vh - 9rem - env(safe-area-inset-top, 0) - env(safe-area-inset-bottom, 0)) !important;
+    height: calc(100vh - 9rem) !important;
     height: calc(-webkit-fill-available - 9rem) !important;
   }
 }


### PR DESCRIPTION
## Fix PWA header/footer safe-area inset inflation on iPhone

On iOS in standalone PWA mode, `env(safe-area-inset-top)` and `env(safe-area-inset-bottom)` resolve to the Dynamic Island / home indicator heights (~47px and ~34px respectively). The header and footer were adding these insets to their `height` *and* expressing them again as `padding-*`, causing the bars to render at roughly 2.5× their intended size. The fix is the standard safe-area pattern: bars keep a fixed `4.5em` height; inset padding pushes content clear of the sensor housing without expanding the bar's bounding box. The iOS-specific `@supports` override that subtracted the insets from `.main-content`'s height is also corrected — since the bars no longer absorb extra height, the viewport math no longer needs to subtract the raw inset values.

## Changes

**`index.html`**
- Added `viewport-fit=cover` to the `<meta name="viewport">` tag. This is the explicit contract required for `env(safe-area-inset-*)` to resolve reliably in PWA mode and for `apple-mobile-web-app-status-bar-style: black-translucent` to function correctly.

**`src/index.css`**
- `@media (max-width: 768px)` — `.app-header`: changed `height: calc(4.5em + env(safe-area-inset-top, 0))` → `height: 4.5em`. The existing `padding-top: env(safe-area-inset-top, 0)` is retained and now solely responsible for clearing the notch/Dynamic Island.
- `@media (max-width: 768px)` — `.app-footer`: same treatment; `height: calc(4.5em + env(safe-area-inset-bottom, 0))` → `height: 4.5em`. Existing `padding-bottom` retained.
- `@supports (-webkit-touch-callout: none)` — `.main-content` height: removed the explicit subtraction of `env(safe-area-inset-top, 0)` and `env(safe-area-inset-bottom, 0)` from the `100vh` calculation. The `9rem` offset (two × `4.5em`) is unchanged and remains correct.

## Review notes

**`align-items` and content centering in the header.** The base `.app-header` rule uses `align-items: center`. With `height: 4.5em` and `padding-top: <inset>`, flex centering distributes the remaining space evenly above and below the children *within* the content zone — visually shifting the title/controls toward the bottom of the `4.5em` block on notched devices. This is the accepted trade-off for this approach and matches how most apps handle it; a more precise solution (e.g., `align-items: flex-end` + explicit bottom padding) was out of scope here. Worth verifying on a physical device that the header content looks intentional, not broken.

**Double-cascade on `.main-content` height.** The mobile `@media` block at lines 964–972 still contains `height: calc(100vh - 9rem)` and `height: calc(-webkit-fill-available - 9rem)`. The `@supports (-webkit-touch-callout: none)` block below it overrides both with the now-corrected values. Cascade order is correct, but the rules in the media block are now redundant on iOS (the `@supports` block always wins). Left as-is to preserve non-iOS behavior; not worth refactoring in this PR.

**`viewport-fit=cover` was already implicitly active.** The insets were resolving before this change (otherwise bars would not have inflated). Adding `viewport-fit=cover` explicitly makes the contract correct and future-proof but is not what caused the bug or the fix. If a reviewer questions why it's included, the answer is correctness hygiene, not causation.

**Playlist overlay positioning** (`top: 4.5em` / `bottom: 4.5em`) does not need adjustment — those values were always relative to the fixed bars' visual height, which remains `4.5em` after this change.

Closes #41